### PR TITLE
Fix sqrt function

### DIFF
--- a/emulator5.cpp
+++ b/emulator5.cpp
@@ -1063,7 +1063,7 @@ static uint64_t sqrt_ (CThread * t) {
         }
         break;
     case 6:   // double
-        if (a.f < 0) {
+        if (a.d < 0) {
             result.q = t->makeNan(nan_invalid_sqrt, operandType);
         }
         else {


### PR DESCRIPTION
The function sometimes rejected float64 numbers
as negative when they were positive. The cause is
a is-negative check as float32 on float64 data.
Fixes issue #6